### PR TITLE
ci: remove maximum branch length requirement

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,6 @@ jobs:
                   allowed_prefixes: build,chore,ci,docs,feat,fix,perf,refactor,style,test
                   ignore: trunk
                   min_length: 5
-                  max_length: 40
             - name: Get branch name
               id: branch-name
               uses: tj-actions/branch-names@v5.1


### PR DESCRIPTION
🤓 Fix PRs failing due to maximum branch length limitation, by removing it