### PR TITLE
chore: increment Node.js version to latest LTS (16) as minimum supported

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ jobs:
         strategy:
             matrix:
                 node:
-                    - 14
                     - 16
                     - 17
                 runner:

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,7 @@
 				"typescript": "4.5.5"
 			},
 			"engines": {
-				"node": ">= 14"
+				"node": ">= 16"
 			}
 		},
 		"node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 	"license": "AGPL-3.0-or-later",
 	"private": true,
 	"engines": {
-		"node": ">= 14"
+		"node": ">= 16"
 	},
 	"os": [
 		"linux",


### PR DESCRIPTION
🆓 We're not bound by AWS/Vercel to Node.js 14 support
⛄️ Railway uses up-to-date buildpacks
👉 Increment supported Node.js versions to only include the latest LTS release (and up)

Closes #54