### PR TITLE
ci: fix github cards workflow

### DIFF
--- a/.github/workflows/cards.yml
+++ b/.github/workflows/cards.yml
@@ -1,8 +1,7 @@
 # This workflow takes care of labeling and closing cards when they move in the project board
 name: Cards
 
-on:
-    project_card: # Run when cards move
+on: project_card # Run when cards move
 
 # Cancel previous instances of this workflow
 concurrency:

--- a/.github/workflows/cards.yml
+++ b/.github/workflows/cards.yml
@@ -3,13 +3,6 @@ name: Cards
 
 on:
     project_card: # Run when cards move
-    workflow_run: # Workflows that act as the `github-actions` bot (using the default GITHUB_TOKEN) can't trigger other workflows (https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)
-        workflows: # List workflows that move cards manually
-            - Draft
-            - Open
-            - Review
-        types:
-            - completed
 
 # Cancel previous instances of this workflow
 concurrency:


### PR DESCRIPTION
🗂 Stop running the GitHub Cards Workflow twice in a row