### PR TITLE
fix: emotion bug

### DIFF
--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -1,30 +1,13 @@
-import type { PropsWithChildren } from "react";
 import { CacheProvider } from "@emotion/react";
-import { useMemo, useState } from "react";
 import { hydrate } from "react-dom";
 import { RemixBrowser } from "remix";
-import { createEmotionCache, EmotionClientContext } from "~app/emotion";
+import { createEmotionCache } from "~app/emotion";
 
-function ClientWrapper({ children }: PropsWithChildren<unknown>) {
-	const [cache, setCache] = useState(createEmotionCache());
-
-	const ctx = useMemo(
-		() => ({
-			reset: () => setCache(createEmotionCache()),
-		}),
-		[],
-	);
-
-	return (
-		<EmotionClientContext.Provider value={ctx}>
-			<CacheProvider value={cache}>{children}</CacheProvider>
-		</EmotionClientContext.Provider>
-	);
-}
+const cache = createEmotionCache();
 
 hydrate(
-	<ClientWrapper>
+	<CacheProvider value={cache}>
 		<RemixBrowser />
-	</ClientWrapper>,
-	document,
+	</CacheProvider>,
+	document.getElementById("__remix"),
 );


### PR DESCRIPTION
🙈 Fix `<style>` elements bleeding into the document `<body>`, a place where they [do not belong](https://github.com/mui/material-ui/issues/26561#issuecomment-855286153)
ℹ️ Removed Remix/React control of the entire document to drastically simplify emotion logic. This also means the Remix `meta`/`link` features no longer work -> [react-helmet](https://github.com/nfl/react-helmet)

Closes #221 