### PR TITLE
chore(renovate): pin React to 17 only for the time being

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -29,6 +29,7 @@
 			"matchPackagePrefixes": ["@remix-run/"]
 		},
 		{
+			"allowedVersions": "17",
 			"groupName": "React",
 			"matchPackageNames": [
 				"react",


### PR DESCRIPTION
🌎 The ecosystem isn't quite ready for React 18 yet, and our app isn't either. We're going to have to remain on React 17 for a while, at least until chakra-ui v2 is released. Until then, it seems reasonable to stop wasting CI resources on renovate trying to keep a bad upgrade PR up-to-date.