### PR TITLE
feat: Add better Link variants

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -35,6 +35,7 @@
 		"donotpresent",
 		"dotenv",
 		"ehthumbs",
+		"esac",
 		"esbuild",
 		"esktop",
 		"ethr",
@@ -68,12 +69,12 @@
 		"Strg",
 		"traversy",
 		"tsbuildinfo",
+		"unstyled",
 		"vsix",
 		"vuepress",
 		"wqhd",
 		"wscript",
 		"wxga",
-		"zalgo",
-		"esac"
+		"zalgo"
 	]
 }

--- a/app/features/chakra/theme.ts
+++ b/app/features/chakra/theme.ts
@@ -1,4 +1,8 @@
-import type { ThemeConfig } from "@chakra-ui/react";
+import type {
+	ChakraTheme,
+	ThemeComponents,
+	ThemeConfig,
+} from "@chakra-ui/react";
 import { extendTheme, withDefaultColorScheme } from "@chakra-ui/react";
 
 /**
@@ -6,16 +10,63 @@ import { extendTheme, withDefaultColorScheme } from "@chakra-ui/react";
  *
  * @see https://chakra-ui.com/docs/styled-system/theming/theme
  */
+
+// generic configuration
 const config: ThemeConfig = {
 	initialColorMode:
 		"system" /* Adapt to light/dark mode on the client, fall back to "light" */,
 	// useSystemColorMode: true,
 };
 
+// chakra component style definitions + overrides
+const components: ThemeComponents = {
+	Link: {
+		/* The Link component comes black-on-white by default, which isn't very visually appealing. This adds a couple additional variants to choose from (recommended: "indicating", which replicates the default link look with chakra colors, default: "unstyled" as shipped by chakra). */
+		baseStyle: {
+			color: "",
+		},
+		defaultProps: {
+			variant: "unstyled",
+		},
+		variants: {
+			browser: {
+				color: "revert",
+			},
+
+			indicating: {
+				_dark: {
+					_visited: {
+						color: "purple.400",
+					},
+					color: "blue.400",
+				},
+				_visited: {
+					color: "purple.600",
+				},
+				color: "blue.600",
+			},
+			normal: {
+				_dark: {
+					color: "blue.400",
+				},
+				color: "blue.600",
+			},
+			unstyled: {
+				color: "inherit",
+			},
+		},
+	},
+};
+
+const all: Partial<ChakraTheme> = {
+	components,
+	config,
+};
+
 export const theme = extendTheme(
-	{ config },
+	all,
 	withDefaultColorScheme({
-		colorScheme: "blue" /* Sets the accent colors of the entire theme */,
+		colorScheme: "blue" /* Sets the accent color for the entire theme */,
 	}),
 ) as {
 	config: typeof config;

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -74,7 +74,7 @@ export function CatchBoundary(): JSX.Element {
 						<Text maxW="lg" my={2} fontSize="sm">
 							{message}
 						</Text>
-						<Link color="revert" href="/">
+						<Link href="/" variant="indicating">
 							Hier geht&apos;s zurück
 						</Link>
 					</chakra.main>
@@ -107,7 +107,7 @@ export function ErrorBoundary({ error }: { error: Error }): JSX.Element {
 							fontSize="sm">
 							{message}
 						</Code>
-						<Link color="revert" href="/">
+						<Link href="/" variant="indicating">
 							Hier geht&apos;s zurück
 						</Link>
 					</chakra.main>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -18,7 +18,7 @@ import {
 } from "remix";
 import { ColorModeToggle, ColorModeManager } from "~app/colormode";
 import { theme } from "~feat/chakra";
-import { LinkButton } from "~feat/links";
+import { Link } from "~feat/links";
 import { keys } from "~lib/util";
 
 function Root({ children }: PropsWithChildren<unknown>) {
@@ -74,9 +74,9 @@ export function CatchBoundary(): JSX.Element {
 						<Text maxW="lg" my={2} fontSize="sm">
 							{message}
 						</Text>
-						<LinkButton href="/" variant="link">
+						<Link color="revert" href="/">
 							Hier geht&apos;s zurück
-						</LinkButton>
+						</Link>
 					</chakra.main>
 				</Center>
 			</ChakraProvider>
@@ -107,9 +107,9 @@ export function ErrorBoundary({ error }: { error: Error }): JSX.Element {
 							fontSize="sm">
 							{message}
 						</Code>
-						<LinkButton href="/" variant="link">
+						<Link color="revert" href="/">
 							Hier geht&apos;s zurück
-						</LinkButton>
+						</Link>
 					</chakra.main>
 				</Center>
 			</ChakraProvider>


### PR DESCRIPTION
🔗 Chakra's `<Link>` component looks very "unstyled" out of the box, with plain black text no different from surrounding markup until it is hovered upon (which hints at its true meaning with a link underline style). In an effort to make it easier to create "normal" anchor elements with sane default stylings, I present to you a bunch of new variants for said component
💭 Recommendation: `indicating` is styled using chakra's color palette, supports dark mode, and "indicates" to the user whether he has visited the linked page before or not with the usual purple tint
✅ The default stays with the new old `unstyled` variant, to maintain compatibility especially with other chakra components relying on `<Link>` internally